### PR TITLE
Fix location_* Request When It's The Only Param

### DIFF
--- a/ngx_http_aws_auth_module.c
+++ b/ngx_http_aws_auth_module.c
@@ -347,7 +347,7 @@ ngx_http_arg2(ngx_http_request_t *r, u_char *name, size_t len, ngx_str_t *value)
         if (ngx_strncasecmp(p, name, len) != 0) {
             continue;
         }
-        if (p == r->args.data || ( *(p + len) == '&' && pos == 0 ) || (p + len) == last || ( *(p + len) == '=' && *(p - 1) == '&') ) {
+        if (( *(p + len) == '&' && pos == 0 ) || (p + len) == last || ( *(p + len) == '=' && *(p - 1) == '&') ) {
             if ((p + len) < last && *(p + len) == '=') {
                 value->data = p + len + 1;
                 p = ngx_strlchr(p, last, '&');


### PR DESCRIPTION
- When "location*" was the only query parameter, we were matching
  it (incorrectly) as a subresource key word.  The fix that was
  implemented already does a better job at this, so removing this
  small check will fix this bug

test plan:
  Roll to edge and try curling or using a course that has some kind
  of "location*" as it's only query parameter. The example bug that I
  was give was "location_id=3" as the only query parameter